### PR TITLE
added new token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tokenlist/apertum-tokenlist.json
+++ b/tokenlist/apertum-tokenlist.json
@@ -3,7 +3,7 @@
   "version": {
     "major": 1,
     "minor": 0,
-    "patch": 10
+    "patch": 11
   },
   "keywords": [
     "apertum",
@@ -92,6 +92,14 @@
       "decimals": 18,
       "address": "0xC84B40231E270B827cEb0A27b78AA3fBa443Cf46",
       "logoURI": "https://github.com/Danilo1103/pugicon/blob/main/pug_icon.png?raw=true"
+    },
+    {
+      "name": "ZOV",
+      "chainId": 2786,
+      "symbol": "ZOV",
+      "decimals": 18,
+      "address": "0x2836Ef32D7D3AA5723eb76aa6287c26891796038",
+      "logoURI": "https://raw.githubusercontent.com/zovdeveloper/zovlogo/main/zovlogo.jpg?raw=true"
     }
   ]
 }

--- a/tokenlist/apertum-tokenlist.json
+++ b/tokenlist/apertum-tokenlist.json
@@ -99,7 +99,7 @@
       "symbol": "ZOV",
       "decimals": 18,
       "address": "0x2836Ef32D7D3AA5723eb76aa6287c26891796038",
-      "logoURI": "https://raw.githubusercontent.com/zovdeveloper/zovlogo/main/zovlogo.jpg?raw=true"
+      "logoURI": "https://raw.githubusercontent.com/zovdeveloper/zovlogo/main/zovlogo.png?raw=true"
     }
   ]
 }


### PR DESCRIPTION
This pull request adds the "ZOV" token to the Apertum Token List.

### Changes:
- **Token Added**:
  - Name: ZOV
  - Chain ID: 2786
  - Symbol: ZOV
  - Decimals: 18
  - Address: 0x2836Ef32D7D3AA5723eb76aa6287c26891796038
  - Logo URI:https://raw.githubusercontent.com/zovdeveloper/zovlogo/main/zovlogo.jpg?raw=true
- **Version**: Incremented from 1.0.10 to 1.0.11
- **Timestamp**: Updated to 2025-04-05T12:00:00+0000

### Validation:
- Ran `npm run validate` locally - passed
- Ran `npm test` locally - passed

### Notes:
- The logo URI points to a publicly accessible image hosted on GitHub.
- No existing tokens were modified, per the validation rules.

Please review and let me know if any adjustments are needed!